### PR TITLE
Add Preliminary Support for Remote Debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,69 @@
                 },
                 "default": [],
                 "description": "Options to be passed to the java executable (java)."
+              },
+              "remoteHost": {
+                "type": "string",
+                "description": "Hostname to attach the jdb connection to. Defaults to localhost",
+                "default": "localhost"
+              },
+              "remotePort": {
+                "type": "number",
+                "description": "Port number to attach the jdb connection to. Defaults to a randomly assigned port",
+                "default": null
+              }
+            }
+          },
+          "attach": {
+            "required": [
+              "jdkPath",
+              "cwd",
+              "startupClass",
+              "remotePort"
+            ],
+            "properties": {
+              "cwd": {
+                "type": "string",
+                "description": "Current working directory (defaults to the directory where the current file is located).",
+                "default": "${fileDirname}"
+              },
+              "startupClass": {
+                "type": "string",
+                "description": "startup class (this will deault to the current file name)",
+                "default": "${fileBasename}"
+              },
+              "jdkPath": {
+                "type": "string",
+                "description": "Path JDK directory.",
+                "default": ""
+              },
+              "stopOnEntry": {
+                "type": "boolean",
+                "description": "Automatically stop after launch.",
+                "default": true
+              },
+              "externalConsole": {
+                "type": "boolean",
+                "description": "Launch debug target in external console window.",
+                "default": false
+              },
+              "options": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Options to be passed to the java executable (java)."
+              },
+              "remoteHost": {
+                "type": "string",
+                "description": "Hostname to attach the jdb connection to. Defaults to localhost",
+                "default": "localhost"
+              },
+              "remotePort": {
+                "type": "number",
+                "description": "Port number to attach the jdb connection to. Defaults to a randomly assigned port",
+                "default": null
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -74,16 +74,6 @@
                 },
                 "default": [],
                 "description": "Options to be passed to the java executable (java)."
-              },
-              "remoteHost": {
-                "type": "string",
-                "description": "Hostname to attach the jdb connection to. Defaults to localhost",
-                "default": "localhost"
-              },
-              "remotePort": {
-                "type": "number",
-                "description": "Port number to attach the jdb connection to. Defaults to a randomly assigned port",
-                "default": null
               }
             }
           },

--- a/src/client/common/contracts.ts
+++ b/src/client/common/contracts.ts
@@ -11,6 +11,15 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
     options?: string[];
 }
 
+export interface AttachRequestArguments extends LaunchRequestArguments {
+    remoteHost?: string;
+    remotePort: number;
+}
+
+export function isAttachRequestArguments(arg: LaunchRequestArguments | AttachRequestArguments): arg is AttachRequestArguments {
+    return (arg as AttachRequestArguments).remotePort !== undefined;
+}
+
 export interface IJavaThread {
     //IsWorkerThread: boolean;
     Name: string;

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -7,7 +7,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
 import {JdbRunner, JdbCommandType} from './jdb';
-import {LaunchRequestArguments, IJavaEvaluationResult, IJavaStackFrame, IJavaThread, JavaEvaluationResultFlags, IDebugVariable, ICommand, IStackInfo} from './common/contracts';
+import {AttachRequestArguments, LaunchRequestArguments, IJavaEvaluationResult, IJavaStackFrame, IJavaThread, JavaEvaluationResultFlags, IDebugVariable, ICommand, IStackInfo} from './common/contracts';
 const LineByLineReader = require('line-by-line');
 const namedRegexp = require('named-js-regexp');
 const ARRAY_ELEMENT_REGEX = new RegExp("^\\w+.*\\[[0-9]+\\]$");
@@ -126,6 +126,11 @@ class JavaDebugSession extends DebugSession {
         }
 
         return null;
+    }
+
+    protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
+        // This seems to work for now. There is no specific configuration for attach, as JdbRunner handles both types of args
+        this.launchRequest(response, args);
     }
 
     protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {


### PR DESCRIPTION
This changeset fixes issue #18 (support remote debugging).

It adds an "Attach" configuration and the required hostname and port fields that are used to bind to an existing jdb session.

Please let me know if there are any issues with this PR, as I'd be happy to fix them.