### PR TITLE
Add maven support

### DIFF
--- a/src/client/jdb.ts
+++ b/src/client/jdb.ts
@@ -87,6 +87,12 @@ export class JdbRunner extends EventEmitter {
     public constructor(private args: LaunchRequestArguments, debugSession: DebugSession) {
         super();
         this.debugSession = debugSession;
+        // if using VSCode's ${relativeFile}, it will default to src/main/java/${file}.java
+        if (args.startupClass.startsWith('src/main/java/')) {
+            args.startupClass = args.startupClass.split('src/main/java/')[1];
+            args.startupClass = args.startupClass.substring(0, args.startupClass.lastIndexOf('.java'));
+            args.startupClass = args.startupClass.replace(/\//g, '.');
+        }
         let ext = path.extname(args.startupClass);
         this.className = path.basename(args.startupClass, ext.toUpperCase() === ".JAVA" ? ext : "");
         this.jdbLoaded = new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
To achieve debugging a maven project after 'mvn compile,' one needs to tweak the launch.json configuration with the following:

```
"startupClass": "${relativeFile}",
"options": [
  "-classpath",
  "${workspaceRoot}/target/classes"
]
```