### PR TITLE
Add separate option for classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,14 @@ Example launch configuration (launch.json):
     "name": "Java",
     "type": "java",
     "request": "launch",
-    "stopOnEntry": true,      
+    "stopOnEntry": true,
     "preLaunchTask": "build",                 // Runs the task created above before running this configuration
     "jdkPath": "${env:JAVA_HOME}/bin",        // You need to set JAVA_HOME enviroment variable
     "cwd": "${workspaceRoot}",
     "startupClass": "my.package.MyMainClass", // The class you want to run
     "sourcePath": ["${workspaceRoot}/src"],   // Indicates where your source (.java) files are
-    "options": [
-      "-classpath", "${workspaceRoot}/bin"    // Idicates the location of your .class files
-    ]
+    "classpath": ["${workspaceRoot}/bin"],    // Indicates the location of your .class files
+    "options": []                             // Additional options to pass to the java executable
 }
 ```
 
@@ -56,7 +55,7 @@ Example launch configuration (launch.json):
 
 ## Release Notes
 
-See [Change 
+See [Change
 Log](https://github.com/DonJayamanne/javaVSCode/blob/master/CHANGELOG.md)
 
 ## Big thanks to [Faustino Aguilar](https://github.com/faustinoaq)
@@ -64,7 +63,7 @@ Log](https://github.com/DonJayamanne/javaVSCode/blob/master/CHANGELOG.md)
 ## Source
 
 [Github](https://github.com/DonJayamanne/javaVSCode)
-                
+
 ## License
 
 [MIT](https://raw.githubusercontent.com/DonJayamanne/javaVSCode/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ Example launch configuration (launch.json):
 
 ## Release Notes
 
-See [Change
-Log](https://github.com/DonJayamanne/javaVSCode/blob/master/CHANGELOG.md)
+See [ChangeLog](https://github.com/DonJayamanne/javaVSCode/blob/master/CHANGELOG.md)
 
 ## Big thanks to [Faustino Aguilar](https://github.com/faustinoaq)
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
                 "description": "Launch debug target in external console window.",
                 "default": false
               },
-              "sourcePath":{
+              "sourcePath": {
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -75,13 +75,21 @@
                 "default": [],
                 "description": "SourcePath to search source"
               },
+              "classpath": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Directories, zips, and jars containing the relevant .class files."
+              },
               "options": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 },
                 "default": [],
-                "description": "Options to be passed to the java executable (java). -classpath option uses ';' as path separator in Windows and ':' in Unix"
+                "description": "Options to be passed to the java executable (java). -classpath should be specified with the classpath option instead."
               }
             }
           },
@@ -118,13 +126,21 @@
                 "description": "Launch debug target in external console window.",
                 "default": false
               },
+              "classpath": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Directories, zips, and jars containing the relevant .class files."
+              },
               "options": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 },
                 "default": [],
-                "description": "Options to be passed to the java executable (java). -classpath option uses ';' as path separator in Windows and ':' in Unix"
+                "description": "Options to be passed to the java executable (java). -classpath should be specified with the classpath option instead."
               },
               "remoteHost": {
                 "type": "string",

--- a/src/client/common/contracts.ts
+++ b/src/client/common/contracts.ts
@@ -9,6 +9,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
     externalConsole?: boolean;
     debugOptions?: string[];
     sourcePath?: string[];
+    classpath?: string[];
     options?: string[];
 }
 


### PR DESCRIPTION
This fully resolves #37 by creating a new option in `launch.json` for setting the classpath as an array, which gets joined by the correct OS-dependent separator. By doing this it also allows the launch configuration to work on multiple platforms.

Since this changes the proper structure of launch.json, I figured it may be a good idea to have a warning when the classpath is specified inside the options key of `launch.json`. Therefore, the PR includes a change to output the warning in the debug console. However, I'm not sure if this would be an important enough change to bring to people's attention, or if giving the warning this way is the best way to do it.

VS Code also trimmed a lot of trailing whitespace. Hopefully that's okay.
