### PR TITLE
Fix xterm hold

### DIFF
--- a/src/client/common/open.ts
+++ b/src/client/common/open.ts
@@ -50,7 +50,7 @@ export function open(opts: any): Promise<childProcess.ChildProcess> {
     } else {
         // It use xterm instead of xdg-open because is widely extended in distro world
         cmd = 'xterm';
-        args.push('+hold', '-e');
+        args.push('-hold', '-e');
 
         if (opts.app) {
             args.push(opts.app);


### PR DESCRIPTION
Fix wait behavior when using external console on Linux.

Source: [run xterm -e without terminating](https://stackoverflow.com/questions/10845372/run-xterm-e-without-terminating/13303477#13303477)