### PR TITLE
Use correct output categories

### DIFF
--- a/src/client/jdb.ts
+++ b/src/client/jdb.ts
@@ -206,7 +206,7 @@ export class JdbRunner extends EventEmitter {
             var options = this.args.options || [];
             if (options.indexOf("-classpath") !== -1 || options.indexOf("-cp") !== -1) {
                 this.debugSession.sendEvent(
-                    new OutputEvent("Warning: Specifying -classpath in options of launch.json is deprecated. Please use the classpath option instead.", "warning")
+                    new OutputEvent("Warning: Specifying -classpath in options of launch.json is deprecated. Please use the classpath option instead.", "console")
                 );
             }
             var args = [`-agentlib:jdwp=transport=dt_socket,server=y,address=${port}`].concat(classpathOptions).concat(options).concat(this.className);
@@ -253,7 +253,7 @@ export class JdbRunner extends EventEmitter {
             var dataStr = data.toString();
             if (this.javaServerAppStarted && this.readyToAcceptCommands) {
                 if (!this.args.externalConsole) {
-                    this.debugSession.sendEvent(new OutputEvent(dataStr));
+                    this.debugSession.sendEvent(new OutputEvent(dataStr, "stdout"));
                 }
             }
             else {


### PR DESCRIPTION
I've noticed that the output of the Java program being debugged is always yellow, while with other debuggers it's white. Also, in my last PR the warning I created was white, while it should have been yellow. Here are what the colors are currently:

![image](https://user-images.githubusercontent.com/18223213/27255683-d57f8860-5358-11e7-9343-c679773cf54c.png)

When looking at the DOM, VS Code adds a `warn` class to the output of the Java program, which doesn't really make sense as the first line should be styled as a warning.

This pull request makes the output look like this:

![image](https://user-images.githubusercontent.com/18223213/27255708-0cd05178-5359-11e7-8e07-f51d819a813b.png)

by categorizing the warning message as `console` (which gets registered as a warning) and the output as `stdout` (before it was `console` which is the default category).