### PR TITLE
Keep windows open after debugging

### DIFF
--- a/src/client/common/open.ts
+++ b/src/client/common/open.ts
@@ -34,11 +34,11 @@ export function open(opts: any): Promise<childProcess.ChildProcess> {
 
     } else if (process.platform === 'win32') {
         cmd = 'cmd';
-        args.push('/c', 'start', '');
+        args.push('/c', 'start', '', 'cmd', '/k');
 
         // if (opts.wait) {
-        args.push('/wait');
-        //  }
+        //    args.push('/wait');
+        // }
 
         if (opts.app) {
             args.push(opts.app);


### PR DESCRIPTION
Keep windows open after debugging in windows using `cmd /k` like `-hold` option in xterm.

Related comment on [#46](https://github.com/DonJayamanne/javaVSCode/issues/46#issuecomment-308892264)