### PR TITLE
New property listenerMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
                 },
                 "default": [],
                 "description": "Command line arguments passed to the startup  class."
+              },
+              "listenerMessage": {
+                "type": "string",
+                "description": "expected output of the debugged java process (use '-' if your JVM doesn't print a message like 'Listening for transport...')",
+                "default": "Listening for transport"
               }
             }
           },

--- a/src/client/common/contracts.ts
+++ b/src/client/common/contracts.ts
@@ -5,6 +5,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
     cwd: string;
     startupClass: string;
     jdkPath?: string;
+    listenerMessage?: string;
     stopOnEntry?: boolean;
     externalConsole?: boolean;
     debugOptions?: string[];

--- a/src/client/jdb.ts
+++ b/src/client/jdb.ts
@@ -251,6 +251,14 @@ export class JdbRunner extends EventEmitter {
                 });
             return;
         }
+
+        if (this.args.listenerMessage == null) {
+            this.args.listenerMessage = "Listening for transport";
+        } else if (this.args.listenerMessage == "-") {
+            this.javaServerAppStarted = true;
+            this.javaLoadedResolve(port);
+        }
+
         this.javaProc.stdout.on("data", (data) => {
             var dataStr = data.toString();
             if (this.javaServerAppStarted && this.readyToAcceptCommands) {
@@ -260,7 +268,7 @@ export class JdbRunner extends EventEmitter {
             }
             else {
                 accumulatedData += dataStr;
-                if (accumulatedData.indexOf("Listening for transport") === 0 && accumulatedData.trim().endsWith(port.toString())) {
+                if (accumulatedData.indexOf(this.args.listenerMessage) === 0 && accumulatedData.trim().endsWith(port.toString())) {
                     accumulatedData = "";
                     this.javaServerAppStarted = true;
                     this.javaLoadedResolve(port);


### PR DESCRIPTION
allows to use the JVM's which
- don't print the 'Listening for transport' message
  (use a value of '-')
- print a different message

Implements:
https://github.com/DonJayamanne/javaVSCode/issues/57